### PR TITLE
More cross platform compat fixes

### DIFF
--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -72,7 +72,7 @@ void Lexer::processFile(String fileName)
 void Lexer::processFileInternal(String fileName)
 {
 	FileNameStack << fileName;
-	FILE* fp = fopen (fileName, "r");
+	FILE* fp = fopen (fileName, "rb");
 
 	if (fp == null)
 		error ("couldn't open %1 for reading: %2", fileName, strerror (errno));

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -39,6 +39,20 @@ static Lexer*		MainLexer = null;
 Lexer::Lexer()
 {
 	ASSERT_EQ (MainLexer, null);
+
+	// Dummy token in the beginning to set m_tokenPosition to a pos before the first actual token
+	{
+		assert(m_tokens.isEmpty());
+		TokenInfo nulltok;
+		nulltok.type = Token::Any;
+		nulltok.file = "";
+		nulltok.line = -1;
+		nulltok.column = -1;
+		nulltok.text = "";
+		m_tokens << nulltok;
+	}
+	m_tokenPosition = m_tokens.begin();
+
 	MainLexer = this;
 }
 
@@ -53,18 +67,6 @@ Lexer::~Lexer()
 //
 void Lexer::processFile(String fileName)
 {
-	assert(m_tokens.isEmpty());
-
-	// Dummy token in the beginning to set m_tokenPosition to a pos before the first actual token
-	TokenInfo nulltok;
-	nulltok.type = Token::Any;
-	nulltok.file = fileName;
-	nulltok.line = -1;
-	nulltok.column = -1;
-	nulltok.text = "";
-
-	m_tokens << nulltok;
-
 	processFileInternal(fileName);
 }
 // _________________________________________________________________________________________________

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -51,6 +51,12 @@ public:
 	Lexer();
 	~Lexer();
 
+    // Disable copying and moving to keep m_tokenPosition iteration valid
+    Lexer(const Lexer&) = delete;
+    Lexer& operator= (const Lexer&) = delete;
+    Lexer(const Lexer&&) = delete;
+    Lexer& operator=(const Lexer&& other) = delete;
+
 	void	processFile (String fileName);
 	bool	next (Token req = Token::Any);
 	void	mustGetNext (Token tok);


### PR DESCRIPTION
- ftell on Windows behaves as in spec and result doesn't relate to size of file for text mode, fixed by changing file reading to binary mode
- m_tokenPosition initial value was incompatible with m_token.begin()/end() iterators