### PR TITLE
Fix flooding stack with unused returns for command calls

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -195,7 +195,11 @@ void BotscriptParser::parseBotscript (String fileName)
 				if (comm)
 				{
 					currentBuffer()->mergeAndDestroy (parseCommand (comm));
-					m_lexer->mustGetNext (Token::Semicolon);
+					m_lexer->mustGetNext(Token::Semicolon);
+
+					if (comm->returnvalue != TYPE_Void) {
+						currentBuffer()->writeHeader(DataHeader::Drop);
+					}
 					continue;
 				}
 


### PR DESCRIPTION
Fixes #10 

~~This is a quick fix. Proper fix should also keep note of current stack depth and assert it is empty when closing scope (or may be on semicolon).~~